### PR TITLE
Only add deps when necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,8 @@ pub fn main() {
 `````
 
 ## Todo
-1. check if the dependencies are already defined before adding them.
-2. Add integration tests.
-3. Commit an escript along with each release.
+1. Add integration tests.
+2. Commit an escript along with each release.
 
 ## Development
 


### PR DESCRIPTION
Now the gleam.toml file gets checked before adding new dependencies and gets skipped if they already exist. This avoids an extra callout out to `gleam add` which is somewhat slow since it has to resolve dependencies.