### PR TITLE
Avoid inefficient list.length(x) > 0

### DIFF
--- a/src/gleam_script/script.gleam
+++ b/src/gleam_script/script.gleam
@@ -14,7 +14,7 @@ pub fn new(path: String) -> Script {
   io.abort_unless(
     msg: "error: missing dependencies",
     code: 1,
-    unless: list.length(dependencies) > 0,
+    unless: dependencies != [],
   )
 
   Script(path:, contents:, dependencies:)


### PR DESCRIPTION
This is slow on Erlang and is better replaced by a comparison against an empty list. The new Gleam version now has a warning for this (v1.13.0).